### PR TITLE
Bump protobuf from 3.13.0 to 3.18.3

Bumps [protobuf](https://github.com/protocolbuffers/protobuf) from 3.13.0 to 3.18.3.
- [Release notes](https://github.com/protocolbuffers/protobuf/releases)
- [Changelog](https://github.com/protocolbuffers/protobuf/blob/main/generate_changelog.py)
- [Commits](https://github.com/protocolbuffers/protobuf/compare/v3.13.0...v3.18.3)

---
updated-dependencies:
- dependency-name: protobuf
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -148,7 +148,7 @@ Pillow==5.2.0
 prettytable==0.7.2
 prometheus-client==0.11.0
 prompt-toolkit==3.0.19
-protobuf==3.13.0
+protobuf==3.18.3
 ptyprocess==0.7.0
 publicsuffix2==2.20191221
 pyasn1==0.4.4


### PR DESCRIPTION
- - - - WIFI Lit